### PR TITLE
added an option for button rule to only validate html button

### DIFF
--- a/lib/rules/button.js
+++ b/lib/rules/button.js
@@ -34,7 +34,6 @@ module.exports = {
     },
 
     create: function(context) {
-        console.log('context', context.options);
         const options = context.options[1] || {};
         const testAttribute = options.testAttribute || defaults.testAttribute;
 

--- a/lib/rules/button.js
+++ b/lib/rules/button.js
@@ -22,10 +22,19 @@ module.exports = {
             url: 'https://github.com/davidcalhoun/eslint-plugin-test-selectors/tree/master/docs/rules/button.md'
         },
         fixable: null,
-        schema: defaultRuleSchema
+        schema: {
+            ...defaultRuleSchema,
+            properties: {
+                ...defaultRuleSchema.properties,
+                htmlOnly: {
+                    type: 'boolean'
+                }
+            }
+        }
     },
 
     create: function(context) {
+        console.log('context', context.options);
         const options = context.options[1] || {};
         const testAttribute = options.testAttribute || defaults.testAttribute;
 
@@ -33,13 +42,15 @@ module.exports = {
             JSXOpeningElement: (node) => {
                 const bypass = shouldBypass(node, options, [
                     {
-                        test: ({ elementType }) => !elementType.toLowerCase().includes('button')
+                        test: ({ elementType }) => {
+                            const elType = options.htmlOnly ? elementType : elementType.toLowerCase();
+
+                            return !elType.includes('button');
+                        }
                     }
                 ]);
 
                 if (bypass) return;
-
-                console.log(45454, testAttribute)
 
                 context.report({
                     node,

--- a/readme.md
+++ b/readme.md
@@ -117,6 +117,17 @@ By default all elements with the `readonly` attribute are ignored, e.g. `<input 
 }
 ```
 
+### htmlOnly
+Only supported on `button` rule, this option will exempt React components called Button from the rule.
+
+```json
+{
+    "rules": {
+        "test-selectors/button": ["warn", "always", {"htmlOnly": true}]
+    }
+}
+```
+
 ## Supported Rules
 
 * `test-selectors/anchor`

--- a/tests/lib/rules/button.js
+++ b/tests/lib/rules/button.js
@@ -26,7 +26,8 @@ ruleTester.run('button', rule, {
         { code: `<ButtonContainer data-test-id='foo' />` },
         { code: `<DownloadButton data-test-id='foo' />` },
         { code: `<button disabled />` },
-        { code: `<button readonly />` }
+        { code: `<button readonly />` },
+        { code: `<Button>Foo</Button>`, options: ["warn", {htmlOnly: true}] }
     ].map(parserOptionsMapper),
 
     invalid: [


### PR DESCRIPTION
Ran into an issue where a Button component in our project was being validated even though we don't want it to have data-test-id attributes.

Thought it was a bug at first but button rule seems to explicitly try to be case-insensitive, so I added an option to only validate lowercase <button>.

Consuming the option looks like:

`"test-selectors/button": ["warn", "always", {htmlOnly: true}]`

Also added a test case to cover this option.