### PR TITLE
feature: add onSubmit rule

### DIFF
--- a/docs/rules/onSubmit.md
+++ b/docs/rules/onSubmit.md
@@ -1,0 +1,16 @@
+# Requires the `data-test-id` attribute on elements with the `onSubmit` attribute.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```js
+<Foo onSubmit={ this.handleSubmit } />
+```
+
+Examples of **correct** code for this rule:
+
+```js
+<Foo onSubmit={ this.handleSubmit } data-test-id="name-selector" />
+```
+

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -52,6 +52,10 @@ module.exports = {
         onKeyUp: {
             message: 'Elements with an onKeyUp handler must have a ${ this.attribute } attribute.',
             type: 'JSXOpeningElement'
+        },
+        onSubmit: {
+            message: 'Elements with an onSubmit handler must have a ${ this.attribute } attribute.',
+            type: 'JSXOpeningElement'
         }
     }
 };

--- a/lib/rules/onSubmit.js
+++ b/lib/rules/onSubmit.js
@@ -1,0 +1,49 @@
+/**
+ * @fileoverview Requires test attribute data-test-id on elements with the onSubmit property.
+ */
+const {
+    errors,
+    defaultRuleSchema,
+    defaults
+} = require('../constants');
+
+const {
+    getError,
+    shouldBypass
+} = require('../utils');
+
+module.exports = {
+    meta: {
+        docs: {
+            description: 'Requires test attribute data-test-id on elements with the onSubmit property.',
+            category: 'Possible Errors',
+            recommended: true,
+            url: 'https://github.com/davidcalhoun/eslint-plugin-test-selectors/tree/master/docs/rules/onSubmit.md'
+        },
+        fixable: null,
+        schema: defaultRuleSchema
+    },
+
+    create: function(context) {
+        const options = context.options[1] || {};
+        const testAttribute = options.testAttribute || defaults.testAttribute;
+
+        return {
+            JSXOpeningElement: (node) => {
+                const bypass = shouldBypass(node, options, [
+                    {
+                        attribute: 'onSubmit',
+                        test: ({ attributeValue }) => typeof attributeValue === 'undefined'
+                    }
+                ]);
+
+                if (bypass) return;
+
+                context.report({
+                    node,
+                    message: getError(errors.onSubmit.message, testAttribute)
+                });
+            }
+        };
+    }
+};

--- a/readme.md
+++ b/readme.md
@@ -138,6 +138,7 @@ Only supported on `button` rule, this option will exempt React components called
 * `test-selectors/onClick`
 * `test-selectors/onKeyDown`
 * `test-selectors/onKeyUp`
+* `test-selectors/onSubmit`
 
 ## Further Reading
 

--- a/tests/lib/rules/onSubmit.js
+++ b/tests/lib/rules/onSubmit.js
@@ -1,0 +1,42 @@
+/**
+ * @fileoverview Requires test attribute data-test-id on elements with onSubmit handlers.
+ */
+const rule = require('../../../lib/rules/onSubmit');
+const RuleTester = require('eslint').RuleTester;
+const parserOptionsMapper = require('../../parserOptionsMapper');
+const {
+    defaults,
+    errors
+} = require('../../../lib/constants');
+const { getError } = require('../../../lib/utils');
+
+const { onSubmit } = errors;
+
+const onSubmitError = getError(onSubmit.message, defaults.testAttribute);
+
+const ruleTester = new RuleTester();
+ruleTester.run('onSubmit', rule, {
+    valid: [
+        { code: `<form onSubmit={ this.handleSubmit } data-test-id={ bar }>Foo</form>` },
+        { code: `<form onSubmit={ this.handleSubmit } data-test-id="bar">Foo</form>` },
+        { code: `<form onSubmit={ this.handleSubmit } data-test-id="bar" />` },
+        { code: `<form onSubmit={ () => {} } data-test-id={ bar }>Foo</form>` },
+        { code: `<form onSubmit={ () => {} } data-test-id="bar">Foo</form>` },
+        { code: `<form onSubmit={ () => {} } data-test-id="bar" />` },
+        { code: `<Bar onSubmit={ () => {} } data-test-id={ bar }>Foo</Bar>` },
+        { code: `<Bar onSubmit={ () => {} } data-test-id="bar">Foo</Bar>` },
+        { code: `<Bar onSubmit={ () => {} } data-test-id="bar" />` },
+        { code: `<Bar onSubmit={ () => {} } disabled />` },
+        { code: `<Bar onSubmit={ () => {} } readonly />` }
+    ].map(parserOptionsMapper),
+
+    invalid: [
+        { code: '<form onSubmit={ this.handleSubmit } />', errors: [onSubmitError] },
+        { code: '<form onSubmit={ this.handleSubmit }>foo</form>', errors: [onSubmitError] },
+        { code: '<Bar onSubmit={ this.handleSubmit } />', errors: [onSubmitError] },
+        { code: '<Bar onSubmit={ this.handleSubmit }>foo</Bar>', errors: [onSubmitError] },
+        { code: '<Bar onSubmit={ () => handleSubmit() }>foo</Bar>', errors: [onSubmitError] },
+        { code: '<Bar onSubmit={ () => handleSubmit() } disabled={ foo }>foo</Bar>', errors: [onSubmitError] },
+        { code: '<Bar onSubmit={ () => handleSubmit() } readonly={ foo }>foo</Bar>', errors: [onSubmitError] }
+    ].map(parserOptionsMapper)
+});


### PR DESCRIPTION
This adds a rule for the `onSubmit` property.
I opted to not add it to the recommended settings, but can add it if you think it makes sense.