### PR TITLE
Support multiple test attributes

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -12,8 +12,18 @@ module.exports = {
             "type": "object",
             "properties": {
                 "testAttribute": {
-                    "type": "string"
-                },
+                    "oneOf": [
+                      {
+                        "type": "string",
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                        },
+                      },
+                    ],
+                  },
                 "ignoreDisabled": {
                     "type": "boolean"
                 },

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,7 +12,11 @@ const {
 // regex.
 // https://stackoverflow.com/a/37217166/214017
 const fillTemplate = (str, vars) => {
-    return new Function(`return \`${ str }\`;`).call(vars);
+    vars.attribute = Array.isArray(vars.attribute)
+        ? vars.attribute.join(", or ")
+        : vars.attribute;
+
+    return new Function(`return \`${str}\`;`).call(vars);
 };
 
 /* Determines the value of an HTML Node prop/attribute. */
@@ -20,9 +24,14 @@ const getValue = (node, prop) => getPropValue(getProp(node.attributes, prop));
 
 /* Determines if a node's attribute passes a filter test. */
 const attributeTest = (node, { attribute, test }) => {
-    const attributeValue = getValue(node, attribute);
+    const attrs = Array.isArray(attribute) ? attribute : [attribute];
     const type = elementType(node);
-    return test({ attributeValue, elementType: type });
+    
+    // One of the attributes must be present on the node
+    return attrs.some((attr) => {
+      const attributeValue = getValue(node, attr);
+      return test({ attributeValue, elementType: type });
+    });
 };
 
 module.exports = {

--- a/readme.md
+++ b/readme.md
@@ -101,6 +101,21 @@ The default test attribute expected is `data-test-id`, but you can override it w
 }
 ```
 
+Note: You can also pass multiple attributes 
+
+```json
+{
+  "rules": {
+    "test-selectors/onChange": [
+      "warn",
+      "always",
+      { "testAttribute": ["data-testid", "testId"] }
+    ]
+  }
+}
+```
+
+
 ### ignoreDisabled
 
 By default all elements with the `disabled` attribute are ignored, e.g. `<input disabled />`. If you don't want to ignore this attribute, set `ignoreDisabled` to `false`:
@@ -147,6 +162,8 @@ Only supported on `button` rule, this option will exempt React components called
 - `test-selectors/onKeyDown`
 - `test-selectors/onKeyUp`
 - `test-selectors/onSubmit`
+
+
 
 ## Further Reading
 


### PR DESCRIPTION
This PR addresses this issue here https://github.com/davidcalhoun/eslint-plugin-test-selectors/issues/16

Support multiple test attributes


<img width="1018" alt="Screenshot 2023-08-03 at 9 01 32 PM" src="https://github.com/davidcalhoun/eslint-plugin-test-selectors/assets/5921853/8c0a41d6-6766-490a-ae43-c5152c1f709f">


```js
{
  "rules": {
    "test-selectors/button": [
      "warn",
      "always",
      { "htmlOnly": true, "testAttribute": ["data-testid", "testId"] }
    ]
}
```